### PR TITLE
Add Quorum to Terminal section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [osync](https://github.com/mann1x/osync/)        | Copy local Ollama models to any accessible remote Ollama instance, C# .NET 8 <br /> Open Source :heavy_check_mark: <br /> Windows :heavy_check_mark: <br /> macOS :heavy_check_mark: <br /> Linux x64/arm64 :heavy_check_mark: | Multi-platform downloads  |
 | [ollamarsync](https://github.com/mann1x/ollamarsync/)        | Copy local Ollama models to any accessible remote Ollama instance <br /> Open Source :heavy_check_mark:                          | Multi-platform Python     |
 | [shell-ask](https://github.com/egoist/shell-ask)        | Ask LLM directly from your terminal <br /> Open Source :heavy_check_mark:  <br /> Multi Function :heavy_check_mark:                   | Multi-platform downloads  |
+| [Quorum](https://github.com/Detrol/quorum-cli)        | Multi-agent AI discussions with Ollama auto-discovery <br /> Open Source :heavy_check_mark: <br /> 7 debate methods (Oxford, Socratic, Delphi, etc.) :heavy_check_mark:                   | Multi-platform Python  |
 
 ## Databases
 


### PR DESCRIPTION
Adding [Quorum](https://github.com/Detrol/quorum-cli) - a multi-agent AI discussion CLI with Ollama auto-discovery.

**Features:**
- Auto-discovers Ollama models (just `ollama pull` and it appears)
- 7 structured debate methods (Standard, Oxford, Socratic, Delphi, Brainstorm, Tradeoff, Advocate)
- Supports mixed local + cloud models (Ollama + OpenAI/Claude/Gemini)
- Terminal UI built with React/Ink

Thanks for maintaining this awesome list!