### PR TITLE
feat: add manusilized to Extensions & Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [LangChain.dart Ollama](https://pub.dev/packages/langchain_ollama) | Ollama integration for LangChain.dart| pub.dev |
 
 ## Extensions & Plugins
+
+| Name/Link | Description | Install Type |
+| --- | --- | --- |
+| [manusilized](https://github.com/wd041216-bit/manusilized) | Open Source :heavy_check_mark: <br /> Patches OpenClaw to unlock real-time token streaming, reliable Markdown-fallback tool calling, and context compression for open-source Ollama models (GLM-5, Qwen3, DeepSeek V3.2) | git patch |


### PR DESCRIPTION
## What is manusilized?

[manusilized](https://github.com/wd041216-bit/manusilized) is an open-source patch for [OpenClaw](https://github.com/openclaw/openclaw) that unlocks three capabilities previously unavailable with Ollama models:

1. **Real-time token streaming** — token-by-token output instead of waiting for the full response
2. **Reliable tool calling** — Markdown-fallback mechanism for models (GLM-5, Qwen3, DeepSeek V3.2) that output tool calls as fenced JSON instead of structured API responses
3. **Context compression** — significantly extended task length for long-horizon agentic tasks

## Why it belongs here

This is a direct Ollama integration patch — it specifically targets the Ollama provider in OpenClaw and has been tested with GLM-5, Qwen3-32B, DeepSeek V3.2, and Kimi-K2.5.

## Entry added

Added to the **Extensions & Plugins** section as it patches an existing tool to extend Ollama compatibility.