### PR TITLE
Add Yaw Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [osync](https://github.com/mann1x/osync/)        | Copy local Ollama models to any accessible remote Ollama instance, C# .NET 8 <br /> Open Source :heavy_check_mark: <br /> Windows :heavy_check_mark: <br /> macOS :heavy_check_mark: <br /> Linux x64/arm64 :heavy_check_mark: | Multi-platform downloads  |
 | [ollamarsync](https://github.com/mann1x/ollamarsync/)        | Copy local Ollama models to any accessible remote Ollama instance <br /> Open Source :heavy_check_mark:                          | Multi-platform Python     |
 | [shell-ask](https://github.com/egoist/shell-ask)        | Ask LLM directly from your terminal <br /> Open Source :heavy_check_mark:  <br /> Multi Function :heavy_check_mark:                   | Multi-platform downloads  |
+| [Yaw](https://yaw.sh)        | Terminal emulator with built-in Ollama support, auto-detects local models <br /> No API key needed :heavy_check_mark:                   | Multi-platform downloads  |
 
 ## Databases
 


### PR DESCRIPTION
Adds [Yaw](https://yaw.sh) to the Terminal section.

Yaw is a terminal emulator with built-in Ollama support — auto-detects local models with no API key needed. Available for Windows, macOS, and Linux.