### PR TITLE
Add Otter — AI agent installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [ollamamodelupdater](https://github.com/technovangelist/ollamamodelupdater) | Update ollama models to the latest version in the Library                                                         | Multi-platform downloads  |
 | [osync](https://github.com/mann1x/osync/)        | Copy local Ollama models to any accessible remote Ollama instance, C# .NET 8 <br /> Open Source :heavy_check_mark: <br /> Windows :heavy_check_mark: <br /> macOS :heavy_check_mark: <br /> Linux x64/arm64 :heavy_check_mark: | Multi-platform downloads  |
 | [ollamarsync](https://github.com/mann1x/ollamarsync/)        | Copy local Ollama models to any accessible remote Ollama instance <br /> Open Source :heavy_check_mark:                          | Multi-platform Python     |
+| [Otter](https://github.com/KikoCisBot/otter) | Install anything on your machine using an AI agent — just point it at a README. Zero config, local-first. <br /> Open Source :heavy_check_mark: <br /> TUI :heavy_check_mark: <br /> macOS :heavy_check_mark: <br /> Linux :heavy_check_mark: <br /> Windows :heavy_check_mark: | Rust binary (multi-platform) |
 | [shell-ask](https://github.com/egoist/shell-ask)        | Ask LLM directly from your terminal <br /> Open Source :heavy_check_mark:  <br /> Multi Function :heavy_check_mark:                   | Multi-platform downloads  |
 
 ## Databases


### PR DESCRIPTION
## What

Adds [Otter](https://github.com/KikoCisBot/otter) to the **Agents** section.

## Why

Otter is a zero-config CLI agent that installs anything on your machine — you point it at a README (or just describe what you need), and it reads the docs, checks prerequisites, and executes each step automatically. Destructive operations always ask for confirmation first.

- Local-first: works with Ollama, LM Studio, llama.cpp, MLX — no cloud required
- Single static Rust binary, no runtime needed
- Cross-platform: macOS, Linux, Windows
- Includes TUI