### PR TITLE
Add LocoPilot — vision, browser, and desktop control for Ollama LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
 | [AiLama](https://github.com/zeyoyt/ailama)                          | Open Source :heavy_check_mark: <br /> Discord User App :heavy_check_mark: <br /> Multi Function :heavy_check_mark: <br /> | Gradle+Java <br /> Docker |
 | [Cloud Seeder](https://github.com/ipv6rslimited/cloudseeder)        | One-click deployment and maintenance suite for Ollama and OpenWebUI with external IP                                      | Multi-platform downloads  | 
+| [LocoPilot](https://github.com/bobfromarcher/LocoPilot)            | Vision, browser, and desktop control for Ollama LLMs :heavy_check_mark: <br /> Open Source :heavy_check_mark: <br /> 35 endpoints, zero cloud, one file :heavy_check_mark: <br /> | python |
 | [vnc-m](https://github.com/jake83741/vnc-lm)                        | A Discord bot with support for model downloads, parameter adjustments, conversation branching, and prompt refinement.                   | Docker <br> NPM  |
 
 ## Model Evaluation and Testing Tools


### PR DESCRIPTION
﻿## Summary

Adds [LocoPilot](https://github.com/bobfromarcher/LocoPilot) to the Miscellaneous section.

**LocoPilot** gives Ollama LLMs vision, browser, and desktop control via 35 API endpoints - zero cloud, one file, MIT license. It lets any Ollama model see screens, navigate browsers, and interact with desktop apps entirely locally, making it a powerful tool for the Ollama ecosystem.
