### PR TITLE
Add CrustAI — local AI assistant for Telegram, WhatsApp, Discord and Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,5 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [LangChain.dart Ollama](https://pub.dev/packages/langchain_ollama) | Ollama integration for LangChain.dart| pub.dev |
 
 ## Extensions & Plugins
+
+- [CrustAI](https://github.com/DaveSimoes/CrustAI) - Private, local-first AI assistant powered by Ollama with Telegram, WhatsApp, Discord and Slack integration. Runs 100% locally with no cloud dependency.


### PR DESCRIPTION
Hi! I'd like to add CrustAI to the Web & Desktop UIs list.

CrustAI is a private, self-hosted AI assistant powered 
by Ollama that connects to Telegram, WhatsApp, Discord 
and Slack — running 100% locally with no cloud dependency.

GitHub: https://github.com/DaveSimoes/CrustAI