### PR TITLE
Add ToolPiper to Web & Desktop UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [Chatbox](https://github.com/Bin-Huang/Chatbox)                                      |                                                                                                                                  |
 | [WinForm Ollama Copilot](https://github.com/tgraupmann/WinForm_Ollama_Copilot)       |                                                                                                                                  |
 | [Nosia](https://github.com/nosia-ai/nosia)                                           |                                                                                                                                  |
+| [ToolPiper](https://modelpiper.com/toolpiper) | Mac OS native :heavy_check_mark: <br /> Voice & Vision :heavy_check_mark: <br /> Multi Model Chats :heavy_check_mark: <br /> Pipelines :heavy_check_mark: <br /> MCP Tools :heavy_check_mark: <br /> | Mac OS Native |
 
 ## Mobile Apps
 


### PR DESCRIPTION
ToolPiper is a native macOS app that connects to Ollama as a backend and adds chat, voice, vision, visual pipelines, and 300+ local MCP tools.

https://modelpiper.com/toolpiper