### PR TITLE
feat: add TWZRD Agent Intel to Extensions & Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [LangChain.dart Ollama](https://pub.dev/packages/langchain_ollama) | Ollama integration for LangChain.dart| pub.dev |
 
 ## Extensions & Plugins
+
+| Name/Link                                                           | Description                                                      |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Trust scoring and x402 payment verification for AI agents on Solana. Free: `resolve_agent`, `score_agent`, `preflight_check`. Paid: `get_trust_receipt` (HTTP 402, USDC). Zero-install MCP: `https://intel.twzrd.xyz/mcp` |


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Extensions & Plugins** section.

TWZRD Agent Intel is an MCP server that gives Ollama-powered agents verifiable identity and payment infrastructure for calling paid APIs autonomously:

- **Zero-install MCP endpoint**: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
- **Free tools**: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`
- **Paid tool**: `get_trust_receipt` — HTTP 402 with <1s USDC settlement on Solana mainnet
- PyPI: `pip install twzrd-agent-intel`

Relevant for Ollama users building agents that call external paid APIs — the MCP server acts as a trust layer so agent identity can be verified before payment.