### PR TITLE
Add Nanocoder to Terminal section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [osync](https://github.com/mann1x/osync/)        | Copy local Ollama models to any accessible remote Ollama instance, C# .NET 8 <br /> Open Source :heavy_check_mark: <br /> Windows :heavy_check_mark: <br /> macOS :heavy_check_mark: <br /> Linux x64/arm64 :heavy_check_mark: | Multi-platform downloads  |
 | [ollamarsync](https://github.com/mann1x/ollamarsync/)        | Copy local Ollama models to any accessible remote Ollama instance <br /> Open Source :heavy_check_mark:                          | Multi-platform Python     |
 | [shell-ask](https://github.com/egoist/shell-ask)        | Ask LLM directly from your terminal <br /> Open Source :heavy_check_mark:  <br /> Multi Function :heavy_check_mark:                   | Multi-platform downloads  |
+| [Nanocoder](https://github.com/Nano-Collective/nanocoder) | A local-first coding agent for your terminal <br /> Open Source :heavy_check_mark: <br /> Bring your own model :heavy_check_mark: | Multi-platform Node.js |
 
 ## Databases
 


### PR DESCRIPTION
Adds [Nanocoder](https://github.com/Nano-Collective/nanocoder) to the Terminal section.

**Why it's valuable:** Nanocoder is a local-first, open-source CLI coding agent that runs against local models, making it a natural fit for a self-hosted, terminal-based workflow. You bring your own model and your code stays on your machine.

- Appended to the end of the Terminal section, matching the existing table format
- Description avoids referencing the host runtime by name per CONTRIBUTING
- Open source, actively maintained, link verified