### PR TITLE
Add Sifty to Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [osync](https://github.com/mann1x/osync/)        | Copy local Ollama models to any accessible remote Ollama instance, C# .NET 8 <br /> Open Source :heavy_check_mark: <br /> Windows :heavy_check_mark: <br /> macOS :heavy_check_mark: <br /> Linux x64/arm64 :heavy_check_mark: | Multi-platform downloads  |
 | [ollamarsync](https://github.com/mann1x/ollamarsync/)        | Copy local Ollama models to any accessible remote Ollama instance <br /> Open Source :heavy_check_mark:                          | Multi-platform Python     |
 | [shell-ask](https://github.com/egoist/shell-ask)        | Ask LLM directly from your terminal <br /> Open Source :heavy_check_mark:  <br /> Multi Function :heavy_check_mark:                   | Multi-platform downloads  |
+| [Sifty](https://github.com/Vortrix5/sifty)        | Windows maintenance CLI/TUI with an optional local assistant: ask what is safe to clean and it explains, with the model running on your own Ollama. It only ever sees file metadata, never contents, and never deletes anything itself. <br /> Open Source :heavy_check_mark: <br /> Windows :heavy_check_mark: | Windows, Python |
 
 ## Databases
 


### PR DESCRIPTION
Adding Sifty to the Terminal section.

Sifty is an open-source Windows maintenance tool (CLI and TUI) I build and maintain. The reason it fits here is its optional local assistant: you can ask it things like "what's safe to clean on my C drive?" and it explains, with the model running entirely on your own Ollama instance. Two deliberate constraints worth noting:

- It only ever sends file *metadata* (names, sizes, paths) to the model, never file contents.
- The AI is purely advisory. It never deletes anything itself; any real action is a separate, confirmed step.

I tried to describe it honestly rather than overstate the Ollama angle, since cleaning is the tool's main job and the local assistant is one part of it. Happy to adjust the wording or drop it if you feel it's not a fit for the list.

Repo: https://github.com/Vortrix5/sifty
