### PR TITLE
Add Hivekeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [Cheshire Cat assistant framework](https://github.com/cheshire-cat-ai/core) | AI agent microservice                                                                                  | Docker              |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent)                | Self-improving AI agent by Nous Research                                                               | Download            |
 | [Hermes Desktop](https://hermes-agent.nousresearch.com/)                    | Native AI assistant app by Nous Research                                                               | Download            |
+| [Hivekeep](https://github.com/MarlBurroW/hivekeep)                          | Self-hosted platform running a team of specialized AI agents with persistent memory and a web UI       | Docker              |
 | [LobeHub](https://github.com/lobehub/lobehub)                               | Chief Agent Operator for 7×24 AI team orchestration                                                    | Download            |
 | [OpenClaw](https://github.com/openclaw/openclaw)                            | Personal AI assistant for your devices                                                                 | Download            |
 


### PR DESCRIPTION
Adds Hivekeep to the Assistants section (alphabetical order).

Hivekeep is a self-hosted, MIT-licensed platform to run a team of specialized AI agents with persistent memory and a web UI. It works with Ollama via the OpenAI-compatible connector (LLM + embeddings, e.g. nomic-embed-text). Single Docker container (Bun + SQLite); reachable over Telegram, Slack, Discord and Matrix.

Disclosure: I am the author of Hivekeep.