### PR TITLE
Add Lifeboat (coding-agent failover with local Ollama fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [QA-Pilot: Chat with Code Repository](https://github.com/reid41/QA-Pilot)      | Chat with GitHub repos using local or online LLMs                                                      | python, streamlit        |
 | [shell-ask](https://github.com/egoist/shell-ask)                               | Ask LLM directly from your terminal, Open Source :heavy_check_mark:, Multi Function :heavy_check_mark: | Multi-platform downloads |
 | [WinForm Ollama Copilot](https://github.com/tgraupmann/WinForm_Ollama_Copilot) | Windows Forms Ollama AI copilot application                                                            | Download                 |
+| [Lifeboat](https://github.com/noah-thing/lifeboat) | Runs your coding agent with automatic failover; drops to a local Ollama model on rate limit, ban, or outage, carrying your context | GitHub |
 
 ## Assistants
 


### PR DESCRIPTION
Lifeboat (open-source, MIT) runs your AI coding agent with automatic failover. When a cloud agent hits a rate limit, ban, or outage, it hands the task to the next agent and finally to a local model via **Ollama**, carrying your context. `lifeboat doctor` reads your RAM and recommends an Ollama coding model that fits (e.g. qwen2.5-coder:7b on 16GB). https://github.com/noah-thing/lifeboat — happy to move sections if Coding Agents isn't ideal.